### PR TITLE
This commit should provide a fix #4.

### DIFF
--- a/cvat_reader/_base.py
+++ b/cvat_reader/_base.py
@@ -185,14 +185,12 @@ class Dataset(Iterable[Frame]):
             from .video_reader.cv2_reader import CV2Reader
 
             self.video_reader: CV2Reader = CV2Reader(video_file)
-            self.last_frame_id = int(self.video_reader.capture.get(7))
+            self.last_frame_id = self.video_reader.get_number_of_frames()
         else:
             from .video_reader.dummy_reader import DummyVideoReader
 
             self.video_reader = DummyVideoReader()
             self.last_frame_id = max(track.last_frame_id for track in self.tracks)
-
-
 
     def seek(self, frame_id: int):
         self.video_reader.seek(frame_id)

--- a/cvat_reader/video_reader/cv2_reader.py
+++ b/cvat_reader/video_reader/cv2_reader.py
@@ -26,3 +26,6 @@ class CV2Reader(VideoReader):
         if self.capture:
             self.capture.release()
             self.capture = None
+
+    def get_number_of_frames(self) -> int:
+        return int(self.capture.get(cv2.CAP_PROP_FRAME_COUNT))


### PR DESCRIPTION
CHANGELOG:
- In case `load_videos` is set to true in `open_cvat`, we will take the number of frames from the provided video, instead of from the max frame_id in all tracks. This ensures that frames without labels at the end of a video are not removed. 